### PR TITLE
Add Pages CMS config for singleton pages, collections, and global settings

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,0 +1,143 @@
+media:
+  input: assets/images
+  output: /assets/images
+
+content:
+  - name: home
+    label: Home Page
+    type: file
+    path: index.html
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: description
+        label: Description
+        type: text
+      - name: layout
+        label: Layout
+        type: string
+      - name: navigation_weight
+        label: Navigation Weight
+        type: number
+      - name: body
+        label: Body
+        type: rich-text
+
+  - name: blog
+    label: Blog Page
+    type: file
+    path: blog.html
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: description
+        label: Description
+        type: text
+      - name: layout
+        label: Layout
+        type: string
+      - name: navigation_weight
+        label: Navigation Weight
+        type: number
+      - name: body
+        label: Body
+        type: rich-text
+
+  - name: work
+    label: Work Page
+    type: file
+    path: work.html
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: description
+        label: Description
+        type: text
+      - name: layout
+        label: Layout
+        type: string
+      - name: navigation_weight
+        label: Navigation Weight
+        type: number
+      - name: body
+        label: Body
+        type: rich-text
+
+  - name: posts
+    label: Posts
+    type: collection
+    path: _posts
+    filename: "{year}-{month}-{day}-{primary}.md"
+    view:
+      fields: [title, date, categories]
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: image
+        label: Featured Image
+        type: image
+      - name: categories
+        label: Categories
+        type: string
+        list: true
+      - name: date
+        label: Date
+        type: date
+      - name: excerpt_separator
+        label: Excerpt Marker
+        type: string
+        required: false
+        default: "<!-- excerpt -->"
+      - name: layout
+        label: Layout
+        type: string
+      - name: body
+        label: Body
+        type: rich-text
+
+  - name: work_items
+    label: Work Items
+    type: collection
+    path: _work
+    filename: "{primary}.md"
+    view:
+      fields: [title, style, categories]
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: image
+        label: Featured Image
+        type: image
+      - name: style
+        label: Style
+        type: string
+      - name: categories
+        label: Categories
+        type: string
+        list: true
+      - name: layout
+        label: Layout
+        type: string
+      - name: body
+        label: Body
+        type: rich-text
+
+globals:
+  - name: site_settings
+    label: Site Settings
+    path: _config.yml
+    fields:
+      - name: title
+        label: Site Title
+        type: string
+      - name: description
+        label: Description
+        type: text
+      - name: timezone
+        label: Timezone
+        type: string


### PR DESCRIPTION
### Motivation
- Provide a Pages CMS configuration so the site can be edited via Pages UI by modeling the existing singleton pages and collections. 
- Expose existing front-matter fields (including images) so content editors can update `index.html`, `blog.html`, `work.html`, `_posts/*.md`, and `_work/*.md` without touching code. 
- Ensure image uploads resolve to the site's `assets/images` directory and surface global site settings from `_config.yml` (`title`, `description`, `timezone`).

### Description
- Add a root `.pages.yml` file with `media` input/output pointing to `assets/images` and overall Pages CMS configuration for the repository. 
- Define singleton file models for `index.html`, `blog.html`, and `work.html` with shared fields `title`, `description`, `layout`, `navigation_weight` and an editable `body`. 
- Add a `posts` collection for `_posts` with fields `title`, `image` (image upload), `categories`, `date`, optional `excerpt_separator` support, `layout`, and `body`. 
- Add a `work_items` collection for `_work` with fields `title`, `image` (image upload), `style`, `categories`, `layout`, and `body`, and add a `globals` mapping that exposes `title`, `description`, and `timezone` from `_config.yml`.

### Testing
- Validated YAML syntax by loading `.pages.yml` with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.pages.yml'); puts 'ok'"`, which succeeded. 
- Attempted to validate with Python using `yaml.safe_load`, which failed because the environment lacked the `PyYAML` module. 
- Confirmed that `.pages.yml` exists at the repository root and inspected the file contents to verify the configured models and fields matched the repository front-matter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3520c4918832695c17062dfd40f59)