### PR TITLE
Make templates tolerant of missing front matter and centralize home/footer content

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,0 +1,17 @@
+contact:
+  email_display: hello(at)kasimirsuterwinter.com
+  location: Prague, Czechia
+social_links:
+  - label: Github
+    url: https://github.com/Kasimirsuterwinter
+  - label: Instagram
+    url: https://www.instagram.com/kasimirsuterwinter/
+  - label: Medium
+    url: https://medium.com/@kasimirsw
+  - label: Facebook
+    url: https://www.facebook.com/kasimir.suterwinter
+github_repo_url: https://github.com/Kasimirsuterwinter/kasimirsuterwinter.github.io
+license:
+  label: CC Attribution-ShareAlike 4.0 International License
+  url: http://creativecommons.org/licenses/by-sa/4.0/
+credit: "&lt;/&gt; with <3 by Kasimir Suter Winter"

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -1,0 +1,11 @@
+cover_statement_lines:
+  - I believe in
+  - a human scale,
+  - open source world
+body_statements:
+  - I am on a search for new better paths. Paths of higher levels of social organizing which can catalyze our humanity. I find myself obsessed with architectures of the non physical. As it appears, these are often the actual shapers of our world.
+  - Currently living in Prague, CZ. I am passionate about open source, local distributed manufacturing, and equitable social models for the post capitalist economy. Such as commons networks/ecosystems, and recently crypto economics and <a href="https://holochain.org/">Holochain</a>.
+  - I help lead <a href="http://www.designdisco.org/">Design Disco</a>, a non-profit organization teaching design and design thinking to the youth. I belive everyone can be a designer because design is a problem solving strategy which sees no bordres between professions and disciplins.
+cv:
+  label: Curriculum Vitae
+  url: /assets/documents/180718_Curriculum_Vitae_KSW.pdf

--- a/_data/site_defaults.yml
+++ b/_data/site_defaults.yml
@@ -1,0 +1,2 @@
+fallback_image: K-Logo-Solid-black.png
+fallback_category: General

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,5 @@
 <hr>
+{% assign footer = site.data.footer %}
 <div class="footer-grid">
 
 <!-- when I add a sign up for for newsletter if ever...
@@ -7,19 +8,18 @@
   </div>
   -->
   <div class="footer-social">
-    <a href="https://github.com/Kasimirsuterwinter" class="fade" target="_blank"><p>Github</p></a>
-    <a href="https://www.instagram.com/kasimirsuterwinter/" class="fade" target="_blank"><p>Instagram</p></a>
-    <a href="https://medium.com/@kasimirsw" class="fade" target="_blank"><p>Medium</p></a>
-    <a href="https://www.facebook.com/kasimir.suterwinter" class="fade" target="_blank"><p>Facebook</p></a>
+    {% for social in footer.social_links %}
+    <a href="{{ social.url }}" class="fade" target="_blank"><p>{{ social.label }}</p></a>
+    {% endfor %}
   </div>
   <div class="footer-contact">
-    <p>hello(at)kasimirsuterwinter.com <br>
-      Prague, Czechia </p>
+    <p>{{ footer.contact.email_display }} <br>
+      {{ footer.contact.location }} </p>
   </div>
   <div class="footer-github">
-    <p><a href="https://github.com/Kasimirsuterwinter/kasimirsuterwinter.github.io">Fork this site on Github</a></p>
+    <p><a href="{{ footer.github_repo_url }}">Fork this site on Github</a></p>
   </div>
   <div class="footer-info">
-    <p class="center-info"><a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC Attribution-ShareAlike 4.0 International License</a>  | &lt;/&gt; with <3 by Kasimir Suter Winter</p>
+    <p class="center-info"><a rel="license" href="{{ footer.license.url }}">{{ footer.license.label }}</a>  | {{ footer.credit }}</p>
   </div>
 </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
-
-
 <title> Kasimir Suter Winter </title>
 <link rel="stylesheet" type="text/css" href="/style.css">
+<meta name="description" content="{{ page.description | default: site.description | escape }}">
 
 <meta name="p:domain_verify" content="71283e0d1cef5766a366fbb3fc668f40"/>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 ---
+{% assign post_image = page.image | default: site.data.site_defaults.fallback_image %}
+{% assign post_description = page.description | default: page.excerpt | strip_html | truncate: 160 | default: site.description %}
+{% assign post_category = page.categories | first | default: page.category | default: site.data.site_defaults.fallback_category %}
 <div class="grid-area">
   <div class="posts-grid">
     <div class="post-title">
@@ -9,8 +12,8 @@ layout: default
         <h1>{{ page.title }}</h1>
       </div>
     </div>
-    <div class="post-content">
-      <img src="/assets/images/{{ page.image }}">
+    <div class="post-content" data-category="{{ post_category }}">
+      <img src="/assets/images/{{ post_image }}" alt="{{ post_description }}">
       <p>{{ page.date | date: '%B %d %Y' }}</p>
 
       {{ content }}

--- a/_layouts/work.html
+++ b/_layouts/work.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 ---
+{% assign work_image = page.image | default: site.data.site_defaults.fallback_image %}
+{% assign work_description = page.description | default: page.excerpt | strip_html | truncate: 160 | default: site.description %}
+{% assign work_category = page.categories | first | default: page.category | default: site.data.site_defaults.fallback_category %}
 <div class="grid-area">
   <div class="posts-grid">
     <div class="post-title">
@@ -9,8 +12,8 @@ layout: default
         <h1>{{ page.title }}</h1>
       </div>
     </div>
-    <div class="post-content">
-      <img src="/assets/images/{{ page.image }}">
+    <div class="post-content" data-category="{{ work_category }}">
+      <img src="/assets/images/{{ work_image }}" alt="{{ work_description }}">
       <p>{{ page.date | date: '%B %d %Y' }}</p>
 
       {{ content }}

--- a/blog.html
+++ b/blog.html
@@ -9,9 +9,12 @@ navigation_weight: 3
   <ul class="blog-grid">
     <a href="/blog"><h3 class="bold"> Blog </h3></a>
     {% for post in site.posts %}
-    <li class="post-list-grid">
+    {% assign post_image = post.image | default: site.data.site_defaults.fallback_image %}
+    {% assign post_description = post.description | default: post.excerpt | strip_html | truncate: 160 | default: site.description %}
+    {% assign post_category = post.categories | first | default: post.category | default: site.data.site_defaults.fallback_category %}
+    <li class="post-list-grid" data-category="{{ post_category }}">
       <a class="post-list-title" href="{{ post.url }}"><h1 class="offset-right" >{{ post.title }}</h1></a>
-      <a href="{{ post.url }}"><img class="post-list-image" src="/assets/images/{{ post.image }}"></a>
+      <a href="{{ post.url }}"><img class="post-list-image" src="/assets/images/{{ post_image }}" alt="{{ post_description }}"></a>
       <p class="post-list-date"> {{ post.date | date: '%B %d %Y' }}</p>
     </li>
     {% endfor %}

--- a/index.html
+++ b/index.html
@@ -6,24 +6,21 @@ navigation_weight: 1
 menu_style: light
 background: k_image
 ---
+{% assign home_data = site.data.home %}
 <div class="front-cover">
  <div class="cover-statement-home">
-    I believe in <br/>
-    a human scale, <br/>
-    open source world <br/>
+    {% for line in home_data.cover_statement_lines %}
+    {{ line }} <br/>
+    {% endfor %}
  </div>
 </div>
 <div class="content-half">
+  {% for statement in home_data.body_statements %}
   <div class="body-statement-home">
-    I am on a search for new better paths. Paths of higher levels of social organizing which can catalyze our humanity. I find myself obsessed with architectures of the non physical. As it appears, these are often the actual shapers of our world.
+    {{ statement }}
   </div>
+  {% endfor %}
   <div class="body-statement-home">
-    Currently living in Prague, CZ. I am passionate about open source, local distributed manufacturing, and equitable social models for the post capitalist economy. Such as commons networks/ecosystems, and recently crypto economics and <a href="https://holochain.org/">Holochain</a>.
-  </div>
-  <div class="body-statement-home">
-    I help lead <a href="http://www.designdisco.org/">Design Disco</a>, a non-profit organization teaching design and design thinking to the youth. I belive everyone can be a designer because design is a problem solving strategy which sees no bordres between professions and disciplins.
-  </div>
-  <div class="body-statement-home">
-    <a href="/assets/documents/180718_Curriculum_Vitae_KSW.pdf">Curriculum Vitae</a>
+    <a href="{{ home_data.cv.url }}">{{ home_data.cv.label }}</a>
   </div>
 </div>

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -96,6 +96,79 @@ models:
         name: introduction
         label: Introduction
 
+
+  home_content:
+    type: data
+    label: Home content
+    file: _data/home.yml
+    singleInstance: true
+    fields:
+      - type: list
+        name: cover_statement_lines
+        label: Cover statement lines
+        items:
+          type: string
+      - type: list
+        name: body_statements
+        label: Body statements
+        items:
+          type: text
+      - type: object
+        name: cv
+        label: CV link
+        fields:
+          - type: string
+            name: label
+            label: Label
+          - type: string
+            name: url
+            label: URL
+
+  footer_content:
+    type: data
+    label: Footer content
+    file: _data/footer.yml
+    singleInstance: true
+    fields:
+      - type: object
+        name: contact
+        label: Contact
+        fields:
+          - type: string
+            name: email_display
+            label: Email
+          - type: string
+            name: location
+            label: Location
+      - type: list
+        name: social_links
+        label: Social links
+        items:
+          type: object
+          fields:
+            - type: string
+              name: label
+              label: Label
+            - type: string
+              name: url
+              label: URL
+      - type: string
+        name: github_repo_url
+        label: Github repository URL
+      - type: object
+        name: license
+        label: License
+        fields:
+          - type: string
+            name: label
+            label: Label
+          - type: string
+            name: url
+            label: URL
+      - type: string
+        name: credit
+        label: Footer credit
+
   article:
     type: page
     label: Blog

--- a/work.html
+++ b/work.html
@@ -7,8 +7,11 @@ navigation_weight: 2
 <div class="grid-area">
   <div class="work-grid">
     {% for work in site.work %}
-    <div id="{{ work.style }}" class="{{ work.style }}" class="align-center" >
-      <a href="{{ work.url }}" ><img class="work-thumbnails" src="/assets/images/{{ work.image }}" ></a>
+    {% assign work_image = work.image | default: site.data.site_defaults.fallback_image %}
+    {% assign work_description = work.description | default: work.excerpt | strip_html | truncate: 160 | default: site.description %}
+    {% assign work_category = work.categories | first | default: work.category | default: site.data.site_defaults.fallback_category %}
+    <div id="{{ work.style }}" class="{{ work.style }}" class="align-center" data-category="{{ work_category }}" >
+      <a href="{{ work.url }}" ><img class="work-thumbnails" src="/assets/images/{{ work_image }}" alt="{{ work_description }}" ></a>
 <!--      <p class="work-thumbnail-title"><a href="{{ work.url }}">{{ work.title }}</a> // {{ work.categories }}</p> -->
     </div>
 


### PR DESCRIPTION
### Motivation
- Prevent pages from breaking when front-matter fields like `image`, `category`, or `description` are missing by providing safe fallbacks. 
- Reduce repeated site-level text (home cover/body and footer) so copy is maintained in one place and can be edited via the CMS. 
- Preserve the existing visual output while simplifying per-page front matter and exposing singleton data records for editing. 

### Description
- Added fallback data in `_data/site_defaults.yml` (`fallback_image`, `fallback_category`) and moved repeated content into `_data/home.yml` and `_data/footer.yml`.
- Updated single-item layouts and listings to use safe Liquid fallbacks for `image`, `description`, and `category` in ` _layouts/posts.html`, `_layouts/work.html`, `blog.html`, and `work.html` (uses `| default:` and centralized `site.data.*` values). 
- Replaced duplicated home and footer markup with data-driven rendering in `index.html` and `_includes/footer.html` using `site.data.home` and `site.data.footer`.
- Added a page description meta fallback in `_includes/head.html` (`<meta name="description" content="{{ page.description | default: site.description | escape }}">`).
- Added CMS singleton data models for `home_content` and `footer_content` in `stackbit.yaml` so the moved content is editable via the CMS.
- Improved accessibility/markup by supplying `alt` attributes for images and adding `data-category` attributes on listing elements.

### Testing
- YAML parse checks: ran `ruby -e "require 'yaml'; YAML.load_file('stackbit.yaml'); YAML.load_file('_data/home.yml'); YAML.load_file('_data/footer.yml'); YAML.load_file('_data/site_defaults.yml')"` and it succeeded. 
- `bundle install`: attempted but failed due to upstream RubyGems `403 Forbidden` in this environment, so gems could not be installed. 
- `bundle exec jekyll build`: could not complete because dependencies were not installable in this environment. 
- Local static serve: started a local static server with `python3 -m http.server` and verified `curl -I http://127.0.0.1:4000/index.html` returned `200 OK`; a Playwright screenshot attempt failed with `ERR_EMPTY_RESPONSE` in the browser runner environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3520447288326a0bff0ea649199c9)