### PR TITLE
Add Pages CMS configuration (.pages.yml) and documentation

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,143 +1,168 @@
 media:
   input: assets/images
   output: /assets/images
+  categories: [image]
 
 content:
+  - name: site_config
+    label: Site Settings
+    type: file
+    path: _config.yml
+    format: yaml
+    fields:
+      - name: title
+        label: Site title
+        type: string
+        required: true
+      - name: description
+        label: Site description
+        type: text
+      - name: timezone
+        label: Timezone
+        type: string
+        default: UTC
+      - name: email
+        label: Contact email
+        type: string
+
   - name: home
     label: Home Page
     type: file
     path: index.html
+    format: yaml-frontmatter
     fields:
-      - name: title
-        label: Title
-        type: string
-      - name: description
-        label: Description
-        type: text
       - name: layout
-        label: Layout
         type: string
+        default: default
+        hidden: true
+      - name: title
+        type: string
+        required: true
+      - name: description
+        type: text
       - name: navigation_weight
-        label: Navigation Weight
         type: number
+      - name: menu_style
+        type: string
+      - name: background
+        type: string
       - name: body
-        label: Body
-        type: rich-text
+        label: Page content
+        type: text
 
-  - name: blog
+  - name: blog_page
     label: Blog Page
     type: file
     path: blog.html
+    format: yaml-frontmatter
     fields:
-      - name: title
-        label: Title
-        type: string
-      - name: description
-        label: Description
-        type: text
       - name: layout
-        label: Layout
         type: string
+        default: default
+        hidden: true
+      - name: title
+        type: string
+        required: true
+      - name: description
+        type: text
       - name: navigation_weight
-        label: Navigation Weight
         type: number
       - name: body
-        label: Body
-        type: rich-text
+        label: Page content
+        type: text
 
-  - name: work
+  - name: work_page
     label: Work Page
     type: file
     path: work.html
+    format: yaml-frontmatter
     fields:
-      - name: title
-        label: Title
-        type: string
-      - name: description
-        label: Description
-        type: text
       - name: layout
-        label: Layout
         type: string
+        default: default
+        hidden: true
+      - name: title
+        type: string
+        required: true
+      - name: description
+        type: text
       - name: navigation_weight
-        label: Navigation Weight
         type: number
       - name: body
-        label: Body
-        type: rich-text
+        label: Page content
+        type: text
 
   - name: posts
-    label: Posts
+    label: Blog Posts
     type: collection
     path: _posts
-    filename: "{year}-{month}-{day}-{primary}.md"
+    filename: '{year}-{month}-{day}-{primary}.md'
+    format: yaml-frontmatter
     view:
-      fields: [title, date, categories]
+      primary: title
+      fields: [title, date, categories, image]
+      sort: [date, title]
+      default:
+        sort: date
+        order: desc
     fields:
-      - name: title
-        label: Title
+      - name: layout
         type: string
+        default: posts
+        hidden: true
+      - name: title
+        type: string
+        required: true
+      - name: date
+        type: date
+      - name: published
+        type: boolean
       - name: image
-        label: Featured Image
         type: image
+        description: Featured image shown on the blog list page.
       - name: categories
-        label: Categories
         type: string
         list: true
-      - name: date
-        label: Date
-        type: date
       - name: excerpt_separator
-        label: Excerpt Marker
         type: string
-        required: false
-        default: "<!-- excerpt -->"
-      - name: layout
-        label: Layout
-        type: string
+        description: Marker used by Jekyll to split excerpts.
       - name: body
-        label: Body
-        type: rich-text
+        type: text
 
   - name: work_items
     label: Work Items
     type: collection
     path: _work
-    filename: "{primary}.md"
+    filename: '{primary}.md'
+    format: yaml-frontmatter
     view:
-      fields: [title, style, categories]
+      primary: title
+      fields: [title, categories, style, image]
+      sort: [title, style]
+      default:
+        sort: title
+        order: asc
     fields:
+      - name: layout
+        type: string
+        default: work
+        hidden: true
       - name: title
-        label: Title
         type: string
+        required: true
       - name: image
-        label: Featured Image
         type: image
+        description: Thumbnail image for the portfolio grid.
       - name: style
-        label: Style
         type: string
+        required: true
+        description: CSS class/id used by the work listing grid.
       - name: categories
-        label: Categories
         type: string
         list: true
-      - name: layout
-        label: Layout
-        type: string
       - name: body
-        label: Body
-        type: rich-text
-
-globals:
-  - name: site_settings
-    label: Site Settings
-    path: _config.yml
-    fields:
-      - name: title
-        label: Site Title
-        type: string
-      - name: description
-        label: Description
         type: text
-      - name: timezone
-        label: Timezone
-        type: string
+
+settings:
+  content:
+    merge: true

--- a/docs/pages-cms-setup.md
+++ b/docs/pages-cms-setup.md
@@ -1,0 +1,33 @@
+# Pages CMS setup for this site
+
+This repository is now configured for [Pages CMS](https://pagescms.org/) with a root `.pages.yml` file.
+
+## Editing workflow
+
+- Repository: `kasimirsuterwinter.github.io`
+- Branch: `main`
+- Publishing mode: direct commits to `main` (single-maintainer workflow)
+
+## Content areas in CMS
+
+- **Site Settings** → `_config.yml` (`title`, `description`, `timezone`, `email`)
+- **Home Page** → `index.html`
+- **Blog Page** → `blog.html`
+- **Work Page** → `work.html`
+- **Blog Posts** → `_posts/*.md`
+- **Work Items** → `_work/*.md`
+
+## Media
+
+Media uploads are configured to:
+
+- `input: assets/images`
+- `output: /assets/images`
+
+This matches current templates where featured images are rendered from `/assets/images/...`.
+
+## Notes
+
+- `settings.content.merge: true` is enabled so existing non-exposed keys are preserved when saving.
+- `layout` is hidden for posts and work entries to avoid accidental template changes.
+- If needed later, add a second media group for documents in `assets/documents`.


### PR DESCRIPTION
### Motivation
- Expose site and page metadata to a Pages CMS UI so non-technical users can edit site settings, pages, blog posts and work items.
- Standardize frontmatter format and visible fields for pages, posts, and work entries to improve editing UX and prevent accidental template changes.
- Document the CMS setup and media paths for maintainers and future contributors.

### Description
- Added a complete `.pages.yml` configuration with a new `site_config` file mapping to `_config.yml`, per-page `home`, `blog`, and `work` file definitions using `yaml-frontmatter`, and `posts` and `work_items` collections with explicit `filename`, `format`, `view`, and `fields` definitions.
- Introduced `media.categories: [image]`, added `settings.content.merge: true`, hid `layout` fields for content types, converted `body`/content fields to `text` frontmatter, and added metadata fields such as `date`, `published`, `image` descriptions, `menu_style`, and `background`. 
- Removed the old `globals` block and consolidated site settings into the `site_config` entry so `_config.yml` keys are edited through the CMS. 
- Added `docs/pages-cms-setup.md` that documents the repository, branch, publishing mode, content areas, media paths, and notes about `settings.content.merge` and hidden layout fields.

### Testing
- Validated the modified YAML with `yamllint` and confirmed there are no syntax errors. 
- No automated unit tests were added or modified in this change set; CI configuration was not altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34fad5ef08326bdbc68b116aa4dc9)