### PR TITLE
Add carousel images field to work items CMS config

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -153,6 +153,11 @@ content:
       - name: image
         type: image
         description: Thumbnail image for the portfolio grid.
+      - name: images
+        type: image
+        label: Carousel Images
+        list: true
+        description: Multiple images shown in the carousel on the work detail page.
       - name: style
         type: string
         required: true


### PR DESCRIPTION
## Summary
- Adds a new `images` field (type: image, list: true) to the work items collection in Pages CMS
- Allows selecting multiple images per work item to power the carousel on work detail pages
- The existing `image` field is kept for the portfolio grid thumbnail

## Test plan
- [ ] Open Pages CMS and verify the "Carousel Images" field appears on work items
- [ ] Add multiple images to a work item and confirm they render in the carousel on the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)