### PR TITLE
Fix gradient ring artifacts on painting canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,9 +170,7 @@ navigation_weight: 1
     g.addColorStop(0.85, 'rgba(' + rgb + ', 0.01)');
     g.addColorStop(1,    'rgba(' + rgb + ', 0)');
     offCtx.fillStyle = g;
-    offCtx.beginPath();
-    offCtx.arc(x, y, r, 0, Math.PI * 2);
-    offCtx.fill();
+    offCtx.fillRect(x - r, y - r, r * 2, r * 2);
     blit();
   }
 


### PR DESCRIPTION
## Summary
- Replaces `arc` + `fill` with `fillRect` when drawing radial gradient brush strokes on the offscreen canvas
- The arc path was anti-aliasing a visible circle edge at radius 140 that accumulated into rings over repeated strokes in the same area
- Since the radial gradient already fades to `rgba(..., 0)` at the outer radius, no circular clipping is needed

## Test plan
- [ ] Paint strokes repeatedly over the same area on the homepage — no visible rings should accumulate around individual brush strokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)